### PR TITLE
[codex] add Matrix discovery files

### DIFF
--- a/.well-known/matrix/client
+++ b/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{"m.homeserver":{"base_url":"https://matrix.rtb.cat"}}

--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{"m.server":"matrix.rtb.cat:443"}


### PR DESCRIPTION
Adds Matrix .well-known discovery files for the rtb.cat homeserver delegation to matrix.rtb.cat.

Changes:
- Adds /.well-known/matrix/client pointing Matrix clients at https://matrix.rtb.cat.
- Adds /.well-known/matrix/server pointing federation/discovery at matrix.rtb.cat:443.
- Adds .nojekyll so GitHub Pages publishes the dot-directory as static files.

Validation:
- Verified both JSON files parse with jq.
- Confirmed the diff is limited to the Matrix discovery files and .nojekyll.